### PR TITLE
Add Joke Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -1,8 +1,35 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Operation;
+
+@Tag(name = "Jokes from https://v2.jokeapi.dev/joke/")
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Gets jokes about various topics")
+    @GetMapping("/get")
+    public ResponseEntity<String> getJokes(
+            @Parameter(name = "category", example = "Programming") @RequestParam String category,
+            @Parameter(name = "number of jokes", example = "2") @RequestParam Integer numJokes)
+            throws JsonProcessingException {
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    JokeQueryService jokeQueryService;
+
+    @Test
+    public void test_getJokes() throws Exception {
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+        String category = "Programming";
+        Integer numJokes = 2;
+        when(jokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?category=%s&numJokes=%d", category, numJokes);
+
+        MvcResult response = mockMvc
+                .perform(get(url).contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}


### PR DESCRIPTION
Added endpoint at /api/jokes/get to get jokes from joke API. This can be used to get a specified number of jokes from a given category.

https://team01-dayvidwang-dev.dokku-08.cs.ucsb.edu/api/jokes/get?category={category}&numJokes={numJokes}

Closes #7 